### PR TITLE
Update OpenAPI Docs and Add Prototype/AOP to Inject

### DIFF
--- a/_http/_nav.ftl
+++ b/_http/_nav.ftl
@@ -45,7 +45,16 @@
       <li><a href="#roles-jex">Jex</a></li>
     </ul>
   </@nav>
-  <@nav url="#openapi" title="OpenAPI"/>
+  <@nav url="#openapi" title="OpenAPI">
+    <ul>
+      <li><a href="#doc">Javadoc</a></li>
+      <li><a href="#response">@OpenApiResponse</a></li>
+      <li><a href="#validation">Validation Annotations</a></li>
+      <li><a href="#swag">Swagger Annotations</a></li>
+      <li><a href="#plug">Maven Plugin</a></li>
+      <li><a href="#serve">Serving OpenApi</a></li>
+    </ul>
+  </@nav>
   <@nav url="#jaxrs" title="JAX-RS comparison"/>
 </ul>
 <p>&nbsp;</p>

--- a/_http/openapi.ftl
+++ b/_http/openapi.ftl
@@ -23,9 +23,16 @@
   The processor reads all the request and response types as OpenAPI component schema. The various annotations like <code>@Header</code>,<code>@Param</code>, and <code>@Produces</code> also modify the generated OpenAPI docs.
 </p>
 
-<h3 id=response>@OpenApiResponse</h3>
+<h4>@Deprecated</h3>
 <p>
-This annotation lets you specify alternate endpoint response status codes/descriptions/types. This is useful for defining error scenarios, and when using the underlying Javalin/Helidon contructs in void methods.
+  Adding Javas's <code>@Deprecated</code> annotation to a controller method marks it as deprecated in the openAPI definition.
+</p>
+
+<h3 id=response>@OpenApiResponse</h3>
+
+<p>
+  This annotation lets you specify alternate endpoint response status codes/descriptions/types. This is useful for defining error scenarios, and when using the underlying Javalin/Helidon contructs in void methods.
+</p>
 
 <pre content="java">
  @Post("/post")

--- a/_http/openapi.ftl
+++ b/_http/openapi.ftl
@@ -9,23 +9,39 @@
   that the controllers define.
 </p>
 <p>
-  Example <a target="_blank" href="https://github.com/dinject/examples/blob/master/javalin-maven-java-basic/src/main/resources/public/openapi.json">javalin-maven-java-basic</a>
+  Example <a target="_blank" href="https://github.com/avaje/avaje-http/blob/b4a3ccfdea89821456044bc142353f7aa88b69e1/tests/test-javalin-jsonb/src/main/java/org/example/myapp/web/test/OpenAPIController.java">Javalin OpenAPI Controller</a>.
+  <br>
+  Generated <a target="_blank" href="https://github.com/avaje/avaje-http/blob/b4a3ccfdea89821456044bc142353f7aa88b69e1/tests/test-javalin-jsonb/src/test/java/io/avaje/http/generator/expectedOpenApi.json">OpenAPI Definition</a>.
 </p>
 
-<h3>Javadoc</h3>
+<h3 id=doc>Javadoc</h3>
 <p>
   The annotation processor reads the javadoc (and Kotlin documentation) of the controller methods to generate the openAPI definition.
   The javadoc summary, description, @param and @return
-  documentation are used to create the OpenAPI Operation summary, description, body content, and response content respectively. The processor
-  reads all the request and response types as OpenAPI component schema.
+  documentation are used to create the OpenAPI Operation definitions.
+  <br>
+  The processor reads all the request and response types as OpenAPI component schema. The various annotations like <code>@Header</code>,<code>@Param</code>, and <code>@Produces</code> also modify the generated OpenAPI docs.
 </p>
 
-<h3>Avaje Annotation</h3>
+<h3 id=response>@OpenApiResponse</h3>
 <p>
-  The various annotations like <code>@Header</code>,<code>@Param</code>, and <code>@Produces</code> also modify the generated OpenAPI docs.
-</p>
+This annotation lets you specify alternate endpoint response status codes/descriptions/types. This is useful for defining error scenarios, and when using the underlying Javalin/Helidon contructs in void methods.
 
-<h3>Validation annotations - @NotNull, @Size, @Email etc</h3>
+<pre content="java">
+ @Post("/post")
+ @OpenAPIResponse(responseCode = "200", description = "overrides @return javadoc description")
+ @OpenAPIResponse(responseCode = "201") // Will use @return javadoc description
+ @OpenAPIResponse(
+      responseCode = "404",
+      description = "User not found (Will not have an associated response schema)")
+ @OpenAPIResponse(
+      responseCode = "500",
+      description = "Some other Error (Will have this error class as the response class reference)",
+      type = ErrorResponse.class)
+ ResponseModel endpoint() {}
+</pre>
+
+<h3 id=validation>Validation Annotations - @NotNull, @Size, @Email etc</h3>
 <p>
   The javax bean validation annotations <code>@NotNull</code>, <code>@Size</code>
   and <code>@Email</code> are read as well as detecting Kotlin non-nullable
@@ -35,7 +51,7 @@
   These are used to specify required properties, min max lengths and property format.
 </p>
 
-<h3>Swagger annotations</h3>
+<h3 id=swag>Swagger annotations</h3>
 <p>
   We can add a dependency on <code>io.swagger.core.v3:swagger-annotations:2.0.8</code>
   and add swagger annotations.
@@ -93,7 +109,7 @@ openapi {
 </pre>
 
 
-<h3>Maven plugin</h3>
+<h3 id=plug>Maven Plugin</h3>
 <p>
   The maven plugin by default puts the generated openapi.json file into
   <em>src/main/resource/public</em>
@@ -142,7 +158,7 @@ openapi {
   </plugin>
 </pre>
 
-<h3>Serving openapi.json</h3>
+<h3 id=serve>Serving openapi.json</h3>
 <p>
   When the openapi.json file is in src/main/resources/public it can be served by
   using <code>addStaticFiles</code> on the JavalinConfig like:

--- a/_inject/_nav_inject.ftl
+++ b/_inject/_nav_inject.ftl
@@ -32,6 +32,7 @@
     <li><a href="#bean">@Bean</a></li>
     <li><a href="#primary">@Primary</a></li>
     <li><a href="#secondary">@Secondary</a></li>
+    <li><a href="#prototype">@Prototype</a></li>
   </ul>
 </@nav>
 <@nav url="#qualifiers" title="Qualifiers">
@@ -56,6 +57,19 @@
     <li><a href="#bean-scope">BeanScope</a></li>
   </ul>
 </@nav>
+<@nav url="#modules" title="Modules">
+  <ul>
+    <li><a href="#unnamed-module">Unnamed Module</a></li>
+    <li><a href="#single-module">Single Module</a></li>
+    <li><a href="#multi-module">Multi-module</a></li>
+    <li><a href="#inject-module">@InjectModule</a></li>
+  </ul>
+</@nav>
+<@nav url="#aop" title="AOP">
+  <ul>
+    <li><a href="#aspect">@Aspect</a></li>
+  </ul>
+</@nav>
 <@nav url="#testing" title="Testing">
   <ul>
     <li><a href="#unit-testing">Unit Testing</a></li>
@@ -67,14 +81,6 @@
     <li><a href="#inject-test">@InjectTest</a></li>
     <li><a href="#test-scope">@TestScope</a></li>
     <li><a href="#programmatic-testing">Programmatic Testing</a></li>
-  </ul>
-</@nav>
-<@nav url="#modules" title="Modules">
-  <ul>
-    <li><a href="#unnamed-module">Unnamed Module</a></li>
-    <li><a href="#single-module">Single Module</a></li>
-    <li><a href="#multi-module">Multi-module</a></li>
-    <li><a href="#inject-module">@InjectModule</a></li>
   </ul>
 </@nav>
 <@nav url="#why" title="Why avaje-inject exists?">

--- a/_inject/_nav_inject.ftl
+++ b/_inject/_nav_inject.ftl
@@ -96,5 +96,6 @@
   </ul>
 </@nav>
 <@nav url="#spring" title="Spring DI"/>
+<@nav url="#value" title="Why no @Value?"/>
 </ul>
 <p>&nbsp;</p>

--- a/_inject/aop.ftl
+++ b/_inject/aop.ftl
@@ -1,0 +1,97 @@
+<h2 id="aop">Aspect Oriented Programming</h3>
+This library has several contructs that support Aspect Oriented Programmming
+
+<h3 id="aspect">@Aspect</h3>
+<p>
+  We can create an annotation and annotate with <code>@Aspect</code> to define an aspect annotation.
+   Aspect.target() specifies the associated type that implements <code>AspectProvider</code>.
+</p>
+
+<pre content="java">
+@Aspect(target = MyAroundAspect.class)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyAround {
+
+  String name() default "";
+}
+</pre>
+
+<p>The AspectProvider should be a <code>@Singleton</code> that provides a <code>MethodInterceptor</code>. (Which will intercept the method call).</p>
+
+<pre content="java">
+@Singleton
+public class MyAroundAspect implements AspectProvider<MyAround>, MethodInterceptor {
+  @Override
+  public MethodInterceptor interceptor(Method method, MyAround around) {
+    //For the sake of brevity we have made this class also implement MethodInterceptor
+    return this;
+  }
+
+  @Override
+  public void invoke(Invocation invoke) throws Throwable {
+    System.out.println("before args: " + Arrays.toString(invoke.arguments()) + " method: " + invoke.method());
+    try {
+      invoke.invoke();
+    } finally {
+      System.out.println("after");
+    }
+  }
+}
+</pre>
+
+<p>
+With the provider set, we can use our newly created aspect annotation on a class/method to intercept calls.
+</p>
+
+<pre content="java">
+@Singleton
+public class ExampleService {
+
+  @MyAround
+  public String other(
+      String param0, int param1) {
+    return "other " + param0 + " " + param1;
+  }
+}
+</pre>
+
+<p>
+  Avaje will generate a proxy class that will run the aspects for every annotated method.
+</p>
+<pre content="java">
+@Proxy
+@Generated("io.avaje.inject.generator")
+public class ExampleService$Proxy extends ExampleService {
+
+  private final MyAroundAspect myAroundAspect;
+
+  private Method other0;
+  private MethodInterceptor other0MyAround;
+
+  public ExampleService$Proxy(MyAroundAspect myAroundAspect) {
+    super();
+    this.myAroundAspect = myAroundAspect;
+    try {
+      other0 = ExampleService.class.getDeclaredMethod("other", String.class, int.class);
+      other0MyAround = myAroundAspect.interceptor(other0, other0.getAnnotation(MyAround.class));
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public java.lang.String other(String param0, int param1) {
+    var call = new Invocation.Call<>(() -> super.other(param0, param1))
+      .with(this, other0, param0, param1);
+    try {
+      other0MyAround.invoke(call);
+      return call.finalResult();
+    } catch (InvocationException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new InvocationException(e);
+    }
+  }
+}
+</pre>

--- a/_inject/injection.ftl
+++ b/_inject/injection.ftl
@@ -626,3 +626,26 @@ public class DefaultEmailSender implements EmailServer {
   and we use <em>@Primary</em> to indicate the best implementation to use when it is available.
   <em>avaje-inject</em> DI will then wire depending on which modules (jars) are included in the classpath.
 </p>
+
+<h3 id="prototype">@Prototype</h3>
+<p>When the <em>@Prototype</em> annotation is added to a class/factory bean method, a new instance of the bean will be created each time it is requested or wired.</p>
+
+<pre content="java">
+@Prototype
+public class Proto {
+  //every time this bean is requested, the constructor is called to provide another instance
+  ...
+  }
+</pre>
+<pre content="java">
+@Factory
+class ProtoFactory {
+  //every time this bean is requested, the factory method is called to provide another instance
+  @Bean
+  @Prototype
+  Example proto() {
+    return new Example();
+  }
+
+}
+</pre>

--- a/_inject/modules.ftl
+++ b/_inject/modules.ftl
@@ -1,6 +1,8 @@
 
 <h2 id="modules">Modules</h2>
-
+<p>
+  To wire all the beans into a scope, <i>avaje-inject</i> generates module classes that run all the constructors/factory methods and adds all beans to the <i>scope</i>.
+</p>
 <h3 id="unnamed-module">Unnamed Modules</h3>
 <p>
   When we don't specify <em>@InjectModule</em> on a module it is an <em>unnamed module</em>.

--- a/_inject/overview.ftl
+++ b/_inject/overview.ftl
@@ -58,6 +58,7 @@
         <li><a href="#factory">@Factory + @Bean</a></li>
         <li><a href="#primary">@Primary + @Secondary</a></li>
         <li><a href="#test-scope">Test scope</a> component testing</li>
+        <li><a href="#aspect">Aspect Oriented Programming</a> around method advice</li>
       </ul>
     </td>
     <td>

--- a/_inject/testing.ftl
+++ b/_inject/testing.ftl
@@ -24,7 +24,7 @@
   verify(grinder).grindBeans();
 </pre>
 
-<h5>Mockito junit5 extension</h5>
+<h5>Mockito JUnit5 Extension</h5>
 <p>
   Mockito provides a JUnit 5 extension <code>MockitoExtension</code> which can be used
   with JUnit <code>@ExtendWith</code>. With this extension we can annotate fields with
@@ -61,7 +61,7 @@
 
 
 
-<h2 id="component-testing">Component testing</h2>
+<h2 id="component-testing">Component Testing</h2>
 <p>
   Component testing is where we look to run tests that use most of the objects with their real
   behaviour with less mocked / stubbed behaviour. With component testing we are looking to test a scenario / piece
@@ -78,7 +78,7 @@
   <li>Unlike unit tests, test a scenario with little to no mocking or stubbing</li>
 </ul>
 
-<h3 id="test-dependency">dependency</h3>
+<h3 id="test-dependency">Dependency</h3>
 <p>
   Add <em>avaje-inject-test</em> as a test dependency.
 </p>

--- a/config/index.ftl
+++ b/config/index.ftl
@@ -161,10 +161,10 @@
       files to load.
     </p>
 
-    <h5>example</h5>
+    <h5>example in application.yaml</h5>
     <pre content="yml">
-      ## in application.yaml
-      load.properties: /etc/config/myapp.properties /etc/other.yaml
+      ## we don't need to specify path if it's in src/main/resources
+      load.properties: local.properties /etc/other.yaml
     </pre>
     <p>
       After default configuration files are loaded the <em>load.properties</em> property is

--- a/inject/index.html
+++ b/inject/index.html
@@ -4,7 +4,7 @@
   <meta name="bread1" content="Inject" href="/inject/"/>
   <#assign index="active">
 </head>
-<body> 
+<body>
 <#include "/_inject/header.ftl">
 <#include "/_inject/overview.ftl">
 <#include "/_inject/quick.ftl">
@@ -14,8 +14,9 @@
 <#include "/_inject/lifecycle.ftl">
 <#include "/_inject/scope.ftl">
 <#include "/_inject/context.ftl">
-<#include "/_inject/testing.ftl">
 <#include "/_inject/modules.ftl">
+<#include "/_inject/aop.ftl">
+<#include "/_inject/testing.ftl">
 <#include "/_inject/why.ftl">
 <#include "/_inject/http-servers.ftl">
 <#include "/_inject/spring.ftl">

--- a/jsonb/index.html
+++ b/jsonb/index.html
@@ -114,6 +114,9 @@
 
   JsonType<Customer> customerType = jsonb.type(Customer.class);
 
+  // If the type is generic we can specify
+  // JsonType<Customer<T1,T2,...>> customerType = jsonb.type(Types.newParameterizedType(Customer.class, T1.class,T2.class, ...);
+
   Customer customer = ...;
 
   // serialize to json


### PR DESCRIPTION
Inject
- Moves module section above testing (idk, I just feel the testing section should come after we show all the features)
- Adds AOP Section
- Adds Prototype Section
- Adds @Value discussion

HTTP Server
- Add a section about the new OpenAPI Annotation.
- Update nav for Open API
- Link to a more current example controller and its generated openapi.json

Mostly solves https://github.com/avaje/avaje-inject/issues/223