### PR TITLE
Update HTTP/Config docs

### DIFF
--- a/_http-client/_nav.ftl
+++ b/_http-client/_nav.ftl
@@ -74,6 +74,7 @@
       <li><a href="#timeout">@RequestTimeout</a></li>
       <li><a href="#header">@Header</a></li>
       <li><a href="#queryParam">@QueryParam</a></li>
+      <li><a href="#bodystring">@BodyString</a></li>
       <li><a href="#beanParam">@BeanParam</a></li>
       <li><a href="#form">@Form</a></li>
       <li><a href="#formParam">@FormParam</a></li>

--- a/_http/beanparam.ftl
+++ b/_http/beanparam.ftl
@@ -14,6 +14,9 @@ public class CommonParams {
   public Long maxRows;
   public String sortBy;
   public Set<String> filter;
+  //you can use ignore to mark a field as not a request parameter
+  @Ignore
+  public String ignored;
 }
 </pre>
 <p>
@@ -56,8 +59,6 @@ ApiBuilder.get("/cats/search/:type", ctx -> {
   default to being query parameters where as with JAX-RS we need to annotate each of the properties.
   We can do this because we have <em>@Form</em> and "Form beans".
 </p>
-
-
 
 <h4>BeanParam beans with @Header, @Cookie properties</h4>
 <p>

--- a/_http/beanvalidation.ftl
+++ b/_http/beanvalidation.ftl
@@ -1,7 +1,7 @@
 
 <h2 id="bean-validation">Bean validation</h2>
 <p>
-  We can optionally add bean validation through the validator interface.
+  We can optionally add bean validation through the validator interface. We can validate a request body and Form Bean/BeanParam
 </p>
 <p>
   Example: <a target="_blank" href="https://github.com/dinject/examples/blob/master/javalin-maven-java-basic/src/main/java/org/example/myapp/web/HelloController.java#L30">HelloController</a>
@@ -9,7 +9,7 @@
 
 <h3>Add @Valid</h3>
 <p>
-  Add <code>@Valid</code> annotation on controllers/methods that we want bean validation to
+  Add a jakarta/javax/avaje <code>@Valid</code> annotation on controllers/methods and the types that we want bean validation to
   be included for. When we do this controller methods that take a request payload
   will then have the request bean (populated by JSON payload or form parameters)
   validated before it is passed to the controller method.
@@ -19,32 +19,79 @@
 </p>
 <pre content="java">
 @Valid
-@Controller
-@Path("/baz")
+class HelloForm {
+  @NotBlank
+  private String name;
+  private String email;
+  //getters/setters/constructors
+}
+
+@Valid
+class HelloBean {
+  @NotBlank
+  private String name;
+  private String email;
+  //getters/setters/constructors
+}
+
+@Valid
+class BodyClass {
+  @NotBlank
+  private String somefield;
+  //getters/setters/constructors
+}
+</pre>
+<pre content="java">
+@Valid
+@Controller("/baz")
 class BazController  {
 
   @Form
-  @Post
+  @Post("/form")
   void saveForm(HelloForm helloForm) {
+    ...
+  }
+
+  @Post("/bean")
+  void saveBean(@BeanParam HelloBean helloBean) {
+    ...
+  }
+
+  @Post("/body")
+  void saveBody(BodyClass body) {
     ...
   }
 </pre>
 <p>
-  The generated code now includes a validation of the helloForm before it is
+  The generated code now includes validation of the beans before they are
   passed to the controller method. The generated code is:
 </p>
 <pre content="java">
-ApiBuilder.post("/baz", ctx -> {
+ApiBuilder.post("/baz/form", ctx -> {
   ctx.status(201);
-  HelloForm helloForm =  new HelloForm(
+  HelloForm helloForm = new HelloForm(
     ctx.formParam("name"),
     ctx.formParam("email")
   );
-  helloForm.url = ctx.formParam("url");
-  helloForm.startDate = toLocalDate(ctx.formParam("startDate"));
-
   validator.validate(helloForm);       // validation added here !!
   controller.saveForm(helloForm);
+});
+
+ApiBuilder.post("/baz/bean", ctx -> {
+  ctx.status(201);
+  HelloBean helloBean =  new HelloBean(
+    ctx.queryParam("name"),
+    ctx.queryParam("email")
+  );
+  validator.validate(helloBean);       // validation added here !!
+  controller.saveBean(helloBean);
+});
+
+ApiBuilder.post("/baz/body", ctx -> {
+  ctx.status(201);
+  var body = ctx.bodyAsClass(BodyClass.class);
+  validator.validate(body);       // validation added here !!
+  controller.saveBody(helloBean);
 });
 </pre>
 

--- a/_http/openapi.ftl
+++ b/_http/openapi.ftl
@@ -47,6 +47,12 @@
     String field1;
  }
 </pre>
+
+<h4>@Consumes</h3>
+<p>
+  Adding the <code>@Consumes</code> annotation to a controller method let's you control what media type should be generated for the request body in the openAPI definition. This is useful when you are dealing with non-standard request content types.
+</p>
+
 <h4>@Deprecated</h3>
 <p>
   Adding Javas's <code>@Deprecated</code> annotation to a controller method marks it as deprecated in the openAPI definition.

--- a/_http/openapi.ftl
+++ b/_http/openapi.ftl
@@ -38,14 +38,13 @@
  }
 </pre>
 
-<p>In Addition, the generator can read the request/response class field javadoc to generate openAPI component description.</p>
+<p>In Addition, the generator can read the request/response class javadoc to generate openAPI component description.</p>
 <pre content="java">
   class ResponseModel {
     /** field one */
     String field1;
     /** field two */
     String field1;
-
  }
 </pre>
 <h4>@Deprecated</h3>

--- a/_http/openapi.ftl
+++ b/_http/openapi.ftl
@@ -23,6 +23,31 @@
   The processor reads all the request and response types as OpenAPI component schema. The various annotations like <code>@Header</code>,<code>@Param</code>, and <code>@Produces</code> also modify the generated OpenAPI docs.
 </p>
 
+<pre content="java">
+  /**
+   * Example of Open API Get (up to the first period is the operation summary).
+   *
+   * basic Post (This Javadoc description is added to the operation description)
+   *
+   * @param b the body (the param docs are used for query/header/body description)
+   * @return funny phrase (this part of the javadoc is added to the response desc)
+   */
+  @Post("/post")
+  ResponseModel endpoint(RequestModel) {
+  ...
+ }
+</pre>
+
+<p>In Addition, the generator can read the request/response class field javadoc to generate openAPI component description.</p>
+<pre content="java">
+  class ResponseModel {
+    /** field one */
+    String field1;
+    /** field two */
+    String field1;
+
+ }
+</pre>
 <h4>@Deprecated</h3>
 <p>
   Adding Javas's <code>@Deprecated</code> annotation to a controller method marks it as deprecated in the openAPI definition.

--- a/_http/post.ftl
+++ b/_http/post.ftl
@@ -6,7 +6,7 @@
 
 <h3 id="post-json">Post JSON</h3>
 <p>
-  Avaje auto detects that a parameter is a request body if the type is a <code>POJO</code>/<code>byte[]</code>/<code>InputStream</code>. To mark a string parameter as a body, use the <code>@BodyString</code> annotation.
+  Avaje auto detects that a parameter is a request body if the type is a <code>POJO</code>/<code>byte[]</code>/<code>InputStream</code> and not marked with a <code>@BeanParam</code> annotation. To mark a string parameter as a body, use the <code>@BodyString</code> annotation.
 </p>
 <pre content="java">
 @Post

--- a/_http/post.ftl
+++ b/_http/post.ftl
@@ -1,13 +1,12 @@
 
 <h2 id="post">@Post</h2>
 <p>
-  Annotate methods with <code>@Post</code> for HTTP POST web routes. The Post request
-  takes a <em>body</em> and by default that is expected to be in JSON form.
+  Annotate methods with <code>@Post</code> for HTTP POST web routes.
 </p>
 
 <h3 id="post-json">Post JSON</h3>
 <p>
-  A method with <code>@Post</code> is by default expecting a JSON body.
+  Avaje auto detects that a parameter is a request body if the type is a <code>POJO</code>/<code>byte[]</code>/<code>InputStream</code>. To mark a string parameter as a body, use the <code>@BodyString</code> annotation.
 </p>
 <pre content="java">
 @Post
@@ -23,7 +22,7 @@ void save(Customer customer) {
 <pre content="java">
 ApiBuilder.post("/customers", ctx -> {
   ctx.status(201);
-  Customer customer = ctx.bodyAsClass(Customer.class);
+  Customer customer = ctx.bodyStreamAsClass(Customer.class);
   controller.save(customer);
 });
 

--- a/_inject/modules.ftl
+++ b/_inject/modules.ftl
@@ -130,7 +130,7 @@
 <h3>autoRequires</h3>
 <p>
  <em>avaje-inject</em> can also automatically read the classpath/maven dependencies at compile-time to find all the modules and automatically determine the <code>requires</code> dependencies.
- This works fine in most cases, but when you are using the annotation processor with a java 9+ modular project or defined as an annotationProcessorPath in the <code>maven-compiler-plugin</code>, you will need to add the <code>avaje-inject-maven-plugin</code>.
+ This works fine in most cases, but when you are using the annotation processor with a java 9+ modular project or defined as an annotationProcessorPath in the <code>maven-compiler-plugin</code>, you will need to add the <code>avaje-inject-maven-plugin</code>. (For Gradle, use the <code>avaje-inject-gradle-plugin</code>)
 </p>
 
 <pre content="xml">

--- a/_layout/base-http-client.html
+++ b/_layout/base-http-client.html
@@ -4,7 +4,7 @@
   <meta name="bread0" content="avaje" href="/"/>
   <meta name="bread1" content="http" href="/http"/>
   <template id="menuNav"><#include "/_http-client/_nav.ftl"></template>
-  <var id="gitsource">https://github.com/avaje/avaje-http-client</var>
+  <var id="gitsource">https://github.com/avaje/avaje-http/tree/master/http-client</var>
 </head>
 <body data-theme="light">
 <div class="container">

--- a/config/index.ftl
+++ b/config/index.ftl
@@ -342,6 +342,16 @@
         Set<|String> operations = Config.getSet().of("my.operations", "put", "delete");
     </pre>
 
+    <h5>Function</h5>
+    <p>
+      We can also provide a function to map a config to a type.
+    </p>
+    <pre content="java">
+        CustomObj codes = Config.getAs("my.codes", s -> new CustomObj(s));
+
+        Optional<|CustomObj> operations = Config.getAsOptional("my.codes", s -> new CustomObj(s));
+    </pre>
+
 
     <h3 id="setProperty">Set Property</h3>
     <p>
@@ -473,7 +483,7 @@
 
     <h2 id="logging">Event Logging</h2>
     <p>
-      By default, <code>avaje-config</code> will immediately log initialisation events to it's own connfigured system logger. If you want to use your own configured logger, you can extend the <code>ConfigurationLog</code> interface and
+      By default, <code>avaje-config</code> will immediately log initialisation events to it's own configured system logger. If you want to use your own configured logger, you can extend the <code>ConfigurationLog</code> interface and
       register via <code>ServiceLoader</code>. This means you have a
       file at <code>src/main/resources/META-INF/services/io.avaje.config.ConfigurationLog</code>
       which contains the class name of the implementation.

--- a/http-client/index.html
+++ b/http-client/index.html
@@ -1357,7 +1357,6 @@ List<|Bazz> findBazz(long id, LocalDate startDate, String type);
    }
 </pre>
 
-
 <h3 id="header">@Header</h3>
 <p>
   Use <code>@Header</code> for a header parameter.
@@ -1485,6 +1484,26 @@ List<|Cat> findCats(LocalDate bornAfter, String orderBy);  // orderBy implied as
       .body(cat)
       .POST()
       .asVoid();
+  }
+</pre>
+
+<h3 id="bodystring">@BodyString</h3>
+
+  We can specify that a string parameter is a body using <code>@BodyString</code>.
+</p>
+<pre content="java">
+@Post("/stringbody")
+List<|Cat> addCats(@BodyString String body);
+</pre>
+<p>The generated code will be:</p>
+<pre content="java">
+  @Override
+  public List<|Cat> addCats(String body) {
+    return clientContext.request()
+      .path("stringbody")
+      .body(body)
+      .GET()
+      .list(Cat.class);
   }
 </pre>
 


### PR DESCRIPTION
- adds the BodyString docs
- Update validation example
- explain the http post body auto-detection logic
- show example javadoc openAPI config
- update config docs with getAs

sorta depends on HTTP 1.35 being deployed to be accurate