### PR TITLE
Update jsonb docs to mention InetAddress suppport

### DIFF
--- a/jsonb/index.html
+++ b/jsonb/index.html
@@ -60,7 +60,8 @@
     <li>Arrays, Collections, Streams, Lists, Sets, and Maps</li>
     <li>Strings</li>
     <li>Enums</li>
-    <li>Other miscellaneous types (UUID, URL, URI)</li>
+    <li>java.net classes (URL, URI, InetAddress...)</li>
+    <li>Other miscellaneous types (UUID...)</li>
   </ul>
 
   <h2 id="quick-start">Quick Start</h2>


### PR DESCRIPTION
Merge only after, and if, release is published with commit [/avaje-jsonb/#9e6f7f1](https://github.com/avaje/avaje-jsonb/commit/9e6f7f118aa4cbba1515b9cd37337453c15440d1), or PR [/avaje-jsonb#288](https://github.com/avaje/avaje-jsonb/pull/288) introducing this feature.