### PR TITLE
Use logo font for page titles, update README to correctly reference Avaje repository, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Source for the website documentation
 ### 1. Clone website-source repo
 
 ```
-git clone git@github.com:ebean-orm/website-source.git
+git clone git@github.com:avaje/website-source.git
 ```
 
 ### 2. Make a destination directory

--- a/_http/overview.ftl
+++ b/_http/overview.ftl
@@ -1,4 +1,6 @@
-<h1 id="overview">Avaje HTTP Generator</h1>
+<h1 id="overview">
+  <span class="logo">Avaje</span>&thinsp;Http&thinsp;Generator
+</h1>
 <p>
 Library that generates adapter code
 for Jex, Javalin and Helidon SE APIs via Annotation Processing.

--- a/_http/overview.ftl
+++ b/_http/overview.ftl
@@ -15,9 +15,9 @@ for Jex, Javalin and Helidon SE APIs via Annotation Processing.
   </tr>
   <tr>
     <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-    <td><a target="_blank" href="https://github.com/avaje/avaje-http">Github</a></td>
+    <td><a target="_blank" href="https://github.com/avaje/avaje-http">GitHub</a></td>
     <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-http-api">Javadoc</a></td>
-    <td><a target="_blank" href="https://github.com/avaje/avaje-http/issues">Github</a></td>
+    <td><a target="_blank" href="https://github.com/avaje/avaje-http/issues">GitHub</a></td>
     <td><a href="https://github.com/avaje/avaje-http/releases"><img src="https://img.shields.io/maven-central/v/io.avaje/avaje-http-api.svg?label=Maven%20Central"></a></td>
   </tr>
 </table>

--- a/_inject/overview.ftl
+++ b/_inject/overview.ftl
@@ -1,4 +1,6 @@
-<h1 id="overview">Avaje Inject</h1>
+<h1 id="overview">
+  <span class="logo">Avaje</span>&thinsp;Inject
+</h1>
 <p>
   Fast and light dependency injection library for Java and Kotlin developers.
 </p>

--- a/_inject/overview.ftl
+++ b/_inject/overview.ftl
@@ -14,9 +14,9 @@
   </tr>
   <tr>
     <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-    <td><a target="_blank" href="https://github.com/avaje/avaje-inject">Github</a></td>
+    <td><a target="_blank" href="https://github.com/avaje/avaje-inject">GitHub</a></td>
     <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-inject">Javadoc</a></td>
-    <td><a target="_blank" href="https://github.com/avaje/avaje-inject/issues">Github</a></td>
+    <td><a target="_blank" href="https://github.com/avaje/avaje-inject/issues">GitHub</a></td>
     <td><a href="https://github.com/avaje/avaje-inject/releases"><img src="https://img.shields.io/maven-central/v/io.avaje/avaje-inject.svg?label=Maven%20Central"></a></td>
   </tr>
 </table>

--- a/_inject/testing.ftl
+++ b/_inject/testing.ftl
@@ -523,8 +523,8 @@ class MyTestConfiguration {
 
 <h5>3. Replacement</h5>
 <p>
-  Say we have a remote API (e.g. Rest call to Github). We don't want any component tests to actually make <em>real calls</em>
-  to Github. Instead, we want to have a default stub response and have that as the default. This is similar to (2) but more
+  Say we have a remote API (e.g. Rest call to GitHub). We don't want any component tests to actually make <em>real calls</em>
+  to GitHub. Instead, we want to have a default stub response and have that as the default. This is similar to (2) but more
   that the default is more like a stub test double.
 </p>
 

--- a/_layout/b2.html
+++ b/_layout/b2.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="/images/favicon.ico">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto|Source+Sans+Pro|Ubuntu&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto|Source+Sans+Pro|Ubuntu|Kalam&display=swap">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/reset.css">
   <link rel="stylesheet" href="/css/site.css">

--- a/_layout/base.html
+++ b/_layout/base.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="/images/favicon.ico">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto|Source+Sans+Pro|Ubuntu&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto|Source+Sans+Pro|Ubuntu|Kalam&display=swap">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/reset.css">
   <link rel="stylesheet" href="/css/site.css">

--- a/config/index.ftl
+++ b/config/index.ftl
@@ -58,7 +58,9 @@
       </nav>
     </header>
 
-    <h1 id="about">Avaje Config</h1>
+    <h1 id="overview">
+      <span class="logo">Avaje</span>&thinsp;Config
+    </h1>
     <p>
       <em>avaje-config</em> provides external configuration for JVM apps. We can provide configuration
       via <em>yaml</em> or <em>properties</em> files and specify which files to load using
@@ -508,11 +510,11 @@
 
     <h2 id="aws-appconfig">AWS App Config</h2>
     <p>
-      If using AWS App Config as a configuration source (refer: <a href="https://docs.aws.amazon.com/appconfig/">https://docs.aws.amazon.com/appconfig</a>), 
+      If using AWS App Config as a configuration source (refer: <a href="https://docs.aws.amazon.com/appconfig/">https://docs.aws.amazon.com/appconfig</a>),
       then we can use the <em>avaje-aws-appconfig</em> component.
     </p>
 
-    <h4>Step 1: Add dependency</h4> 
+    <h4>Step 1: Add dependency</h4>
     <pre content="xml">
       <dependency>
         <groupId>io.avaje</groupId>
@@ -524,7 +526,7 @@
     <h4>Step 2: Add configuration</h4>
     <p>
       In src/main/resources add configuration like below to specify for <em>aws.appconfig</em> the <em>application, environment, configuration</em>.
-    </p>    
+    </p>
     <pre content="yml">
     # In src/main/resources
     aws.appconfig:
@@ -549,7 +551,7 @@
      {"level":"INFO",
       "logger":"io.avaje.config",
       "message":"Loaded properties from [resource:application.yaml, ConfigurationSource:AppConfigPlugin] "}
-    </pre>	
+    </pre>
     <p>
       To increase the logging we can set the log level of <em>io.avaje.config.appconfig</em> to DEBUG or TRACE.
     </p>

--- a/config/index.ftl
+++ b/config/index.ftl
@@ -77,9 +77,9 @@
       </tr>
       <tr>
         <td><a target="_blank" href="https://github.com/avaje/avaje-config/blob/master/LICENSE">Apache2</a></td>
-        <td><a target="_blank" href="https://github.com/avaje/avaje-config">Github</a></td>
+        <td><a target="_blank" href="https://github.com/avaje/avaje-config">GitHub</a></td>
         <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-config/latest/io.avaje.config/io/avaje/config/package-summary.html">Javadoc</a></td>
-        <td><a target="_blank" href="https://github.com/avaje/avaje-config/issues">Github</a>
+        <td><a target="_blank" href="https://github.com/avaje/avaje-config/issues">GitHub</a>
         </td> <td><a href="https://github.com/avaje/avaje-config/releases"><img src="https://img.shields.io/maven-central/v/io.avaje/avaje-config.svg?label=Maven%20Central"></a></td>
       </tr>
     </table>

--- a/css/site.css
+++ b/css/site.css
@@ -358,3 +358,16 @@ summary {
   font-weight: bold;
   cursor: pointer;
 }
+
+#overview {
+  margin-top: 2rem;
+  font-family: 'Kalam', 'Ubuntu', sans-serif;
+  font-size: 72px;
+  letter-spacing: -4px;
+  text-transform: lowercase;
+  color: var(--body-text-color);
+
+  .logo {
+    color: var(--fg-article);
+  }
+}

--- a/http-client/index.html
+++ b/http-client/index.html
@@ -20,9 +20,9 @@
   </tr>
   <tr>
     <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-    <td><a target="_blank" href="https://github.com/avaje/avaje-http/tree/master/http-client">Github</a></td>
+    <td><a target="_blank" href="https://github.com/avaje/avaje-http/tree/master/http-client">GitHub</a></td>
     <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-http-client">Javadoc</a></td>
-    <td><a target="_blank" href="https://github.com/avaje/avaje-http/issues">Github</a></td>
+    <td><a target="_blank" href="https://github.com/avaje/avaje-http/issues">GitHub</a></td>
     <td><a href="https://github.com/avaje/avaje-http/releases"><img src="https://img.shields.io/maven-central/v/io.avaje/avaje-http-client.svg?label=Maven%20Central"></a></td>
   </tr>
 </table>

--- a/http-client/index.html
+++ b/http-client/index.html
@@ -6,7 +6,9 @@
 </head>
 <body>
 
-<h1 id="overview">Avaje Http Client</h1>
+<h1 id="overview">
+  <span class="logo">Avaje</span>&thinsp;Http&thinsp;Client
+</h1>
 
 <table style="width: 100%;">
   <tr>

--- a/jex/index.html
+++ b/jex/index.html
@@ -21,9 +21,9 @@
     </tr>
     <tr>
       <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-jex">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-jex">GitHub</a></td>
       <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-jex">Javadoc</a></td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-jex/issues">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-jex/issues">GitHub</a></td>
       <td><a href="https://github.com/avaje/avaje-jex/releases"><img
             src="https://img.shields.io/maven-central/v/io.avaje/avaje-jex.svg?label=Maven%20Central"></a></td>
     </tr>

--- a/jex/index.html
+++ b/jex/index.html
@@ -7,7 +7,9 @@
 </head>
 
 <body>
-  <h1 id="overview">Avaje Jex</h1>
+  <h1 id="overview">
+    <span class="logo">Avaje</span>&thinsp;Jex
+  </h1>
 
   <table style="width: 100%;">
     <tr>

--- a/jsonb/index.html
+++ b/jsonb/index.html
@@ -21,11 +21,11 @@
     </tr>
     <tr>
       <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-jsonb">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-jsonb">GitHub</a></td>
       <td><a target="_blank"
           href="https://javadoc.io/doc/io.avaje/avaje-jsonb/latest/io.avaje.jsonb/io/avaje/jsonb/package-summary.html">Javadoc</a>
       </td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-jsonb/issues">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-jsonb/issues">GitHub</a></td>
       <td><a href="https://github.com/avaje/avaje-jsonb/releases"><img
             src="https://img.shields.io/maven-central/v/io.avaje/avaje-jsonb.svg?label=Maven%20Central"></a></td>
     </tr>

--- a/jsonb/index.html
+++ b/jsonb/index.html
@@ -7,8 +7,9 @@
 </head>
 
 <body>
-
-  <h1 id="overview">Avaje Jsonb</h1>
+  <h1 id="overview">
+    <span class="logo">Avaje</span>&thinsp;Jsonb
+  </h1>
 
   <table style="width: 100%;">
     <tr>

--- a/prisms/index.html
+++ b/prisms/index.html
@@ -22,9 +22,9 @@
     </tr>
     <tr>
       <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-prisms">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-prisms">GitHub</a></td>
       <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-prisms/latest/io.avaje.prism/io/avaje/prism/package-summary.html">Javadoc</a></td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-prisms/issues">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-prisms/issues">GitHub</a></td>
       <td><a href="https://github.com/avaje/avaje-prisms/releases"><img
             src="https://img.shields.io/maven-central/v/io.avaje/avaje-prisms.svg?label=Maven%20Central"></a></td>
     </tr>

--- a/prisms/index.html
+++ b/prisms/index.html
@@ -8,7 +8,9 @@
 
 <body>
 
-  <h1 id="overview">Avaje Prisms</h1>
+  <h1 id="overview">
+    <span class="logo">Avaje</span>&thinsp;Prisms
+  </h1>
 
   <table style="width: 100%;">
     <tr>

--- a/spi/index.html
+++ b/spi/index.html
@@ -22,9 +22,9 @@
     </tr>
     <tr>
       <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-spi-service">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-spi-service">GitHub</a></td>
       <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-spi-service">Javadoc</a></td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-spi-service/issues">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-spi-service/issues">GitHub</a></td>
       <td><a href="https://github.com/avaje/avaje-spi-service/releases"><img
             src="https://img.shields.io/maven-central/v/io.avaje/avaje-spi-service.svg?label=Maven%20Central"></a></td>
     </tr>

--- a/spi/index.html
+++ b/spi/index.html
@@ -8,7 +8,9 @@
 
 <body>
 
-  <h1 id="overview">Avaje SPI</h1>
+  <h1 id="overview">
+    <span class="logo">Avaje</span>&thinsp;SPI
+  </h1>
 
   <table style="width: 100%;">
     <tr>

--- a/validator/index.html
+++ b/validator/index.html
@@ -21,9 +21,9 @@
     </tr>
     <tr>
       <td><a href="https://discord.gg/Qcqf9R27BR">Discord</td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-validator">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-validator">GitHub</a></td>
       <td><a target="_blank" href="https://javadoc.io/doc/io.avaje/avaje-validator">Javadoc</a></td>
-      <td><a target="_blank" href="https://github.com/avaje/avaje-validator/issues">Github</a></td>
+      <td><a target="_blank" href="https://github.com/avaje/avaje-validator/issues">GitHub</a></td>
       <td><a href="https://github.com/avaje/avaje-validator/releases"><img
             src="https://img.shields.io/maven-central/v/io.avaje/avaje-validator.svg?label=Maven%20Central"></a></td>
     </tr>

--- a/validator/index.html
+++ b/validator/index.html
@@ -7,7 +7,9 @@
 </head>
 
 <body>
-  <h1 id="overview">Avaje Validator</h1>
+  <h1 id="overview">
+    <span class="logo">Avaje</span>&thinsp;Validator
+  </h1>
 
   <table style="width: 100%;">
     <tr>


### PR DESCRIPTION
Below is a preview of how the change looks:
![image](https://github.com/user-attachments/assets/6ae14e64-e90c-4cce-a9b1-5f246b13d9f6)

Across the documentation, "GitHub" was capitalized as "Github", this has been amended.
Finally, the README was previously referencing ebean documentation repository, which has been amended.