### PR TITLE
Add reference to avaje metrics

### DIFF
--- a/index.ftl
+++ b/index.ftl
@@ -124,6 +124,17 @@
         </td>
       </tr>
       <tr>
+        <th><a href="https://avaje-metrics.github.io">Metrics</a></th>
+        <td>
+          <p>
+            Metrics for the JVM, with `@Timed` classes and methods, gauges, counters, etc.
+          </p>
+          <p>
+            Supports integration with other avaje libraries, ebean, JAX-RS, Spring, Graphite, ElasticSearch, among others.
+          </p><hr/>
+        </td>
+      </tr>
+      <tr>
         <th width="25%"><a href="/graalvm">GraalVM Analysis</a></th>
         <td>
           <p>


### PR DESCRIPTION
This proposes adding an extra field to the landing page that links
to the old website for avaje metrics, to increase discoverability.

It may be that this site was desired to be changed or updated,
but it's probably better to just do this _now_ and change it later
if needs be, because it might help more people find the project.

Note that avaje metrics is available in multiple places:
- The `avaje-metrics` organization on GitHub
- The `avaje-metrics-deprecated` organization on GitHub
- The `avaje/avaje-metrics` repository, in `avaje`
  organization on GitHub
- The `avaje-metrics.github.io` website, also of the
  `avaje-metrics` organization on GitHub

P.S I did not preview how it looks.

CC: @rbygrave
CC: @SentryMan
Signed-off-by: Mahied Maruf <contact@mechite.com>
