### PR TITLE
Add a warn page, a place to add deprecation / migration documentation.

### DIFF
--- a/_layout/base-warn.html
+++ b/_layout/base-warn.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <meta name="layout" content="_layout/b2.html"/>
+  <meta name="bread0" content="avaje" href="/"/>
+</head>
+<body data-theme="light">
+<div class="container">
+  <article id="main-content">
+    <div id="layout-body"></div>
+  </article>
+</div>
+</body>
+</html>

--- a/warn.html
+++ b/warn.html
@@ -1,0 +1,23 @@
+<html>
+
+<head>
+  <meta name="layout" content="_layout/base-spi.html" />
+  <meta name="bread1" content="spi-service" href="/warn/" />
+  <#assign index="active">
+</head>
+
+<body>
+
+  <h2 id="props">avaje-config props.file</h2><hr/>
+  <p>
+    avaje-config has deprecated the use of <code>props.file</code> system property.
+  </p>
+  <p>
+    <b>Action:</b> Change to use <code>config.file</code> system property.
+  </p>
+
+  <p><br><br><br><br><br><br></p>
+
+</body>
+
+</html>


### PR DESCRIPTION
So a page that we can reference in error and warning messages, that provides better documentation / instructions on what to do with specific errors or warnings.