### PR TITLE
Use `<code>` instead of \` \`

### DIFF
--- a/index.ftl
+++ b/index.ftl
@@ -127,7 +127,7 @@
         <th><a href="https://avaje-metrics.github.io">Metrics</a></th>
         <td>
           <p>
-            Metrics for the JVM, with `@Timed` classes and methods, gauges, counters, etc.
+            Metrics for the JVM, with <code>@Timed</code> classes and methods, gauges, counters, etc.
           </p>
           <p>
             Supports integration with other avaje libraries, ebean, JAX-RS, Spring, Graphite, ElasticSearch, among others.


### PR DESCRIPTION
After it went live I realized this minor thing.
In the related commit (PR), I said:
> P.S I did not preview how it looks.

Sorry for the time waster

CC: @SentryMan
Related-to: a214f3f1ef764cdec3a46f4b544abcc0929a7746 (#94)
Signed-off-by: Mahied Maruf <contact@mechite.com>
